### PR TITLE
Don't use player name for key

### DIFF
--- a/ExampleScript1.lua
+++ b/ExampleScript1.lua
@@ -1,7 +1,7 @@
 local manager = require(game.ReplicatedStorage:WaitForChild("LuaCoinManager"))
 
 game.Players.PlayerAdded:connect(function(plr)
-	local key = plr.Name.."_"..plr.userId
+	local key = plr.userId
 	manager:SetupPlayer("MasterBank",key)
 	manager:GetInformation("MasterBank",key)
 end)


### PR DESCRIPTION
Using the player's name as part of the key is bad practice because players can change their name. 